### PR TITLE
Fix for memory leak and exception in file uploads

### DIFF
--- a/plugins-client/ext.uploadfiles/uploadworker.js
+++ b/plugins-client/ext.uploadfiles/uploadworker.js
@@ -72,9 +72,10 @@ self.onmessage = function (e) {
 // uploading file in chunks
 self.uploadChunk = function(chunk, filepath, end, blobsize, next) {
     var http = new XMLHttpRequest();
+    var url = filepath;
     if (self._csrf)
-        filepath += (filepath.indexOf("?") > -1 ? "&" : "?") + "_csrf=" + self._csrf;
-    http.open("PUT", filepath, true);
+        url += (url.indexOf("?") > -1 ? "&" : "?") + "_csrf=" + self._csrf;
+    http.open("PUT", url, true);
     http.onreadystatechange = function(){
         if (http.readyState != 4)
             return;


### PR DESCRIPTION
A memory leak in connections occurs because filepath is modified when self._csrf has a value and is not properly deleted from connections.
If a file is uploaded a second time to the same location and since filepath was not deleted from connections due to renaming, it will not increment connections.length for the second upload, so when the file is done a RangeError exception occurs on the decrement of connections.length since it is zero.
Solution is to retain filepath and create a separate modification for the url, this way filepath matches what is stored in connections.
Easiest way to reproduce is to upload a file twice and look for the RangeError.